### PR TITLE
feat: Plex domain override & enhanced light scene capture

### DIFF
--- a/backend/client.js
+++ b/backend/client.js
@@ -3,6 +3,7 @@ var router = express.Router();
 var axios = require("axios").default;
 var https = require("https");
 var parser = require("xml-js");
+var utils = require("./utils");
 
 const httpsAgent = new https.Agent({
   rejectUnauthorized: false,
@@ -19,7 +20,9 @@ router.post("/", async function (req, res, next) {
   var libraries = [];
   var unauth = false;
 
-  console.info("Retrieving information for Plex Clients...");
+  var PLEX_DOMAIN = await utils.getPlexDomain();
+
+  console.info(`Retrieving information for Plex Clients (using domain: ${PLEX_DOMAIN})...`);
 
   var url = `https://${req.body.bridge.ip}/clip/v2/resource/room`;
 
@@ -166,7 +169,7 @@ router.post("/", async function (req, res, next) {
       message.push("Could not connect to the Hue bridge while requesting smart scenes");
     });
 
-  var url = "https://plex.tv/api/users";
+  var url = `https://${PLEX_DOMAIN}/api/users`;
 
   await axios
     .get(url, { timeout: 10000, params: { "X-Plex-Token": req.body.token } })
@@ -192,7 +195,7 @@ router.post("/", async function (req, res, next) {
       message.push("Issue with connection to online Plex account while requesting friends. Check logs for reason.");
     });
 
-  var url = "https://plex.tv/users/account";
+  var url = `https://${PLEX_DOMAIN}/users/account`;
 
   await axios
     .get(url, { timeout: 10000, params: { "X-Plex-Token": req.body.token } })
@@ -220,7 +223,7 @@ router.post("/", async function (req, res, next) {
       );
     });
 
-  var url = "https://plex.tv/api/servers";
+  var url = `https://${PLEX_DOMAIN}/api/servers`;
 
   await axios
     .get(url, { timeout: 10000, params: { "X-Plex-Token": req.body.token } })
@@ -234,7 +237,7 @@ router.post("/", async function (req, res, next) {
 
       servers.forEach(async (server) => {
         if (server._attributes.owned === "1") {
-          var url = `https://plex.tv/api/servers/${server._attributes.machineIdentifier}`;
+          var url = `https://${PLEX_DOMAIN}/api/servers/${server._attributes.machineIdentifier}`;
           await axios
             .get(url, { timeout: 10000, params: { "X-Plex-Token": req.body.token } })
             .then(function (response) {
@@ -263,7 +266,7 @@ router.post("/", async function (req, res, next) {
       message.push("Issue with connection to online Plex account while requesting servers. Check logs for reason.");
     });
 
-  var url = "https://plex.tv/devices.xml";
+  var url = `https://${PLEX_DOMAIN}/devices.xml`;
 
   await axios
     .get(url, { timeout: 10000, params: { "X-Plex-Token": req.body.token } })

--- a/backend/load.js
+++ b/backend/load.js
@@ -37,7 +37,7 @@ if (process.env.BUILD) {
 
 var fileData = `{"connected": "false","platform":"${
   platform
-}","uuid":"${uuid()}","version":"${appVersion}","branch":"${branch}","build":"${build}","appId":"Lumunarr#${hostname}","clients":[],"settings":{"transition":"0","startHour":"12","startMin":"0","startMed":"1","endHour":"11","endMin":"59","endMed":"2"},"api": "v2"}`;
+}","uuid":"${uuid()}","version":"${appVersion}","branch":"${branch}","build":"${build}","appId":"Lumunarr#${hostname}","clients":[],"settings":{"transition":"0","startHour":"12","startMin":"0","startMed":"1","endHour":"11","endMin":"59","endMed":"2","plexDomain":""},"api": "v2"}`;
 
 try {
   fileData = fs.readFileSync("/config/settings.js");

--- a/backend/thumb.js
+++ b/backend/thumb.js
@@ -2,9 +2,11 @@ var express = require("express");
 var router = express.Router();
 var axios = require("axios").default;
 var parser = require("xml-js");
+var utils = require("./utils");
 
 router.post("/", async function (req, res, next) {
-  var url = "https://plex.tv/users/account";
+  var PLEX_DOMAIN = await utils.getPlexDomain();
+  var url = `https://${PLEX_DOMAIN}/users/account`;
 
   await axios
     .get(url, { params: { "X-Plex-Token": req.body.token } })
@@ -22,7 +24,7 @@ router.post("/", async function (req, res, next) {
     })
     .catch(function (error) {
       if (error.request) {
-        console.error("Could not connect to the Plex sewrver");
+        console.error("Could not connect to the Plex server");
         res.status(403).send("Could not connect to the Plex server");
       }
     });

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -1,0 +1,35 @@
+var fs = require("fs");
+
+function getPlexDomain() {
+  var domain = "plex.tv";
+
+  try {
+    var fileData = fs.readFileSync("/config/settings.js");
+    var settings = JSON.parse(fileData);
+
+    if (settings.settings && settings.settings.plexDomain && settings.settings.plexDomain.trim() !== "") {
+      domain = settings.settings.plexDomain.trim();
+    }
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.error("Error reading/parsing settings for Plex Domain:", err);
+    }
+  }
+
+  if (process.env.PLEX_DOMAIN_OVERRIDE) {
+    domain = process.env.PLEX_DOMAIN_OVERRIDE;
+  }
+
+  var domainRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+  if (!domainRegex.test(domain)) {
+    console.error(`Invalid domain format detected: "${domain}". Using default "plex.tv"`);
+    domain = "plex.tv";
+  }
+
+  return domain;
+}
+
+module.exports = {
+  getPlexDomain,
+};

--- a/frontend/src/components/Settings/Settings.jsx
+++ b/frontend/src/components/Settings/Settings.jsx
@@ -22,6 +22,7 @@ export default class Settings extends Component {
         endMed: this.props.settings.settings.endMed ?? "1",
         latitude: this.props.settings.settings.latitude ?? "",
         longitude: this.props.settings.settings.longitude ?? "",
+        plexDomain: this.props.settings.settings.plexDomain ?? "",
         isLoading: true,
         isSaved: false,
         isError: false,
@@ -39,6 +40,7 @@ export default class Settings extends Component {
         endMed: "1",
         latitude: "",
         longitude: "",
+        plexDomain: "",
         isLoading: true,
         isSaved: false,
         errorRes: "",
@@ -61,6 +63,7 @@ export default class Settings extends Component {
     this.props.settings.settings.endMed = this.state.endMed;
     this.props.settings.settings.latitude = this.state.latitude;
     this.props.settings.settings.longitude = this.state.longitude;
+    this.props.settings.settings.plexDomain = this.state.plexDomain;
 
     var xhr = new XMLHttpRequest();
 
@@ -123,6 +126,10 @@ export default class Settings extends Component {
 
   handleLongitude = (e) => {
     this.setState({ longitude: e.target.value.toString(), isSaved: false });
+  };
+
+  handlePlexDomain = (e) => {
+    this.setState({ plexDomain: e.target.value.toString(), isSaved: false });
   };
 
   render() {
@@ -343,6 +350,37 @@ export default class Settings extends Component {
               onChange={this.handleLongitude}
               size="sm"
             />
+            <div className="div-seperator" />
+            <div className="div-seperator" />
+            {/* Plex Domain Override */}
+            <h5>
+              Plex Domain Override &nbsp;&nbsp;
+              <OverlayTrigger
+                placement="right"
+                overlay={
+                  <Tooltip>
+                    Override the default Plex domain (plex.tv). Leave empty to use the default.
+                    <br />
+                    Example: clients.plex.tv
+                  </Tooltip>
+                }
+              >
+                <img src={Info} className="image-info" alt="Info" />
+              </OverlayTrigger>
+            </h5>
+            <div className="div-seperator" />
+            <Form.Label for="plexDomain">Domain</Form.Label>
+            <Form.Control
+              value={this.state.plexDomain}
+              id="plexDomain"
+              name="plexDomain"
+              onChange={this.handlePlexDomain}
+              size="sm"
+              placeholder="plex.tv"
+            />
+            <div style={{ marginTop: "5px", fontSize: "0.9rem", opacity: 0.8 }}>
+              Currently using: {this.state.plexDomain ? this.state.plexDomain : "plex.tv"}
+            </div>
             <div className="div-seperator" />
             {/* Cancel/Save */}
             {this.state.isEdit ? (

--- a/webhook/index.js
+++ b/webhook/index.js
@@ -25,6 +25,8 @@ let colors = [
 
 var playStorage = [];
 
+const NO_EFFECT = "no_effect";
+
 const httpsAgent = new https.Agent({
   rejectUnauthorized: false,
 });
@@ -383,6 +385,49 @@ async function getChildren(types, roomName, uid, ip, key) {
   return children;
 }
 
+/**
+ * Captures a specific light attribute and adds it to the action object if present.
+ * Handles the different API v2 paths: effects_v2 uses status object, others use direct access.
+ *
+ * @param {Object} light - The source light object from Hue API.
+ * @param {Object} action - The target action object to be sent to the Bridge.
+ * @param {string} parentKey - The parent property key (e.g., "effects_v2", "color_temperature").
+ * @param {string} childKey - The child property key (e.g., "effect", "mirek").
+ * @returns {boolean} True if the attribute was captured, false otherwise.
+ */
+function captureLightAttribute(light, action, parentKey, childKey) {
+  const isEffectsV2 = parentKey === "effects_v2";
+  const value = isEffectsV2
+    ? light[parentKey]?.status?.[childKey]
+    : light[parentKey]?.[childKey];
+
+  if (!value || value === NO_EFFECT) {
+    return false;
+  }
+
+  if (!action.action[parentKey]) {
+    action.action[parentKey] = {};
+  }
+
+  if (isEffectsV2) {
+    // effects_v2 requires nested action object: { action: { effect: "...", parameters: {...} } }
+    if (!action.action[parentKey].action) {
+      action.action[parentKey].action = {};
+    }
+    action.action[parentKey].action[childKey] = value;
+
+    // Capture optional parameters (speed, color) if present
+    const parameters = light[parentKey]?.status?.parameters;
+    if (parameters) {
+      action.action[parentKey].action.parameters = parameters;
+    }
+  } else {
+    action.action[parentKey][childKey] = value;
+  }
+
+  return true;
+}
+
 async function recallDanglingScene(roomName, ip, key) {
   const url = `https://${ip}/clip/v2/resource/scene`;
   var danglingScene = {};
@@ -489,14 +534,23 @@ async function createScene(types, roomName, ip, key, transition) {
       action.action.dimming = { brightness: light.dimming?.brightness || 0 };
     }
 
-    if (light.color) {
-      action.action.color = {
-        xy: {
-          x: light.color?.xy?.x || 0,
-          y: light.color?.xy?.y || 0,
-        },
-      };
+    const effectCaptured = captureLightAttribute(light, action, "effects_v2", "effect");
+
+    // Only add static color/temperature if NO effect is active.
+    // Color and color_temperature are mutually exclusive - prefer color if present.
+    if (!effectCaptured) {
+      if (light.color && light.color.xy) {
+        action.action.color = {
+          xy: {
+            x: light.color.xy.x,
+            y: light.color.xy.y,
+          },
+        };
+      } else {
+        captureLightAttribute(light, action, "color_temperature", "mirek");
+      }
     }
+
     return action;
   });
 


### PR DESCRIPTION
## Summary

Two feature additions:

### 1. Configurable Plex Domain
Currently, `plex.tv` is hardcoded for all Plex API calls. A friend reported that API requests to `plex.tv` were failing, but switching to `clients.plex.tv` (which Plex's own server use for client-facing API calls) resolved the issue.

This adds a configurable Plex domain option so users can switch endpoints without modifying source code:
- New **Plex Domain Override** field in the Settings UI
- Also supports `PLEX_DOMAIN_OVERRIDE` environment variable
- Domain format validation to prevent SSRF/injection
- Falls back to `plex.tv` if not configured or invalid
- New `backend/utils.js` module for shared domain retrieval

### 2. Enhanced Light Scene Capture
Scene snapshots were not capturing all light states. For example, lights running Hue effects (fire, candle, etc.) or using color temperature instead of xy color would not have their state stored.
On play/stop, those lights would lose their effect and restore to a static color instead.

This improves scene snapshot fidelity:
- Captures **color temperature** (mirek) for lights not using xy color
- Captures **effects_v2** (candle, fireplace, etc.) with parameters
- Effects take priority over static color to prevent API conflicts
- Uses raw `color.xy` values instead of falling back to 0

### Minor
- Fixes typo: "sewrver" → "server" in `backend/thumb.js`

## Files Changed
- `backend/utils.js` (new) — Plex domain retrieval with validation
- `backend/client.js` — Uses configurable Plex domain
- `backend/thumb.js` — Uses configurable Plex domain
- `backend/load.js` — Adds `plexDomain` to default settings
- `frontend/src/components/Settings/Settings.jsx` — Plex domain input field
- `webhook/index.js` — `captureLightAttribute` function + createScene improvements